### PR TITLE
Fix small typos in CLI output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,7 +82,7 @@ function isCommand(name: string | undefined): name is CommandName {
 }
 
 if (cli.flags.version) {
-  console.log(`cruztomize: v${version}`)
+  console.log(`crustomize: v${version}`)
   process.exit(0)
 }
 if (command == undefined) {

--- a/lib/lint.ts
+++ b/lib/lint.ts
@@ -20,7 +20,7 @@ export function lint(crustomizePath: string) {
 
   if (result.status !== 0) {
     console.error(
-      "cfn-ling exit code: " + result.status
+      "cfn-lint exit code: " + result.status
     )
     console.error(
       result.stdout


### PR DESCRIPTION
## Summary
- fix CLI version message typo
- fix error message in lint module

## Testing
- `bun test` *(fails: Cannot find package 'ejs' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6867a1be6f648321890148431c80b17e