### PR TITLE
Ensure output folder exists in apply command

### DIFF
--- a/lib/commands/apply.ts
+++ b/lib/commands/apply.ts
@@ -134,6 +134,9 @@ export const apply: ApplyFunction = async (crustomizePath, flags) => {
 
     // Write out the results
     if (flags.output) {
+      if (!fs.existsSync(flags.output)) {
+        fs.mkdirSync(flags.output, { recursive: true })
+      }
       if (!fs.lstatSync(flags.output).isDirectory()) {
         console.error(
           `Output path "${flags.output}" is not a folder. Please specify a folder.`,

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test"
 import { apply } from "../lib/commands/apply"
+import fs from "fs"
+import path from "path"
 
 test("crustomize a path", async() => {
   const crustomizePath = "tests/fixtures/base_variant"
@@ -36,5 +38,20 @@ Resources:
             ExpirationInDays: 123
 `)
   console.log = old
+})
+
+test("creates output directory if missing", async () => {
+  const crustomizePath = "tests/fixtures/base_variant"
+  const outputPath = "tests/tmp_output"
+  fs.rmSync(outputPath, { recursive: true, force: true })
+  const flags = {
+    render: "handlebars",
+    env: "",
+    profile: "",
+    output: outputPath,
+  }
+  await apply(crustomizePath, flags)
+  expect(fs.existsSync(path.join(outputPath, "template.yml"))).toBe(true)
+  fs.rmSync(outputPath, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
## Summary
- create output directory if missing before applying
- test for missing output directory creation

## Testing
- `bun test` *(fails: Cannot find package 'yaml-cfn', 'ejs', 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_6867a44220008321a62cedca27ae8ae1