### PR TITLE
Move getting started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+Crustomize is a small CLI that merges and deploys CloudFormation templates.
+
+### Prerequisites
+
+- [AWS CLI](https://aws.amazon.com/cli/)
+- [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) if you plan to use the `--lint` flag
+- [bun](https://bun.sh) &mdash; only required when building from source
+
+### Installation
+
+1. Download a binary from the release page and place it in your `$PATH`.
+2. Verify the installation:
+
+```bash
+crustomize --help
+```
+
+### Building from source
+
+If you prefer to build the binary yourself:
+
+1. Install dependencies with `bun install`.
+2. Build using `make bundle`.
+3. Copy the executable from `dist/` to your `$PATH`.
+
+See the examples under `examples/` for sample templates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Crustomize lets you build reproducible AWS CloudFormation deployments by merging
 
 ## Contents
 
-- [Getting started](#getting-started)
+- [Getting started](getting-started.md)
 - [Structuring your project](project-structure.md)
 - Writing templates and overlays
 - Deploying to AWS
@@ -12,31 +12,3 @@ Crustomize lets you build reproducible AWS CloudFormation deployments by merging
   - crustomize.yml file
   - [Helper functions](helpers.md)
 
-## Getting Started
-
-Crustomize is a small CLI that merges and deploys CloudFormation templates.
-
-### Prerequisites
-
-- [AWS CLI](https://aws.amazon.com/cli/)
-- [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) if you plan to use the `--lint` flag
-- [bun](https://bun.sh) &mdash; only required when building from source
-
-### Installation
-
-1. Download a binary from the release page and place it in your `$PATH`.
-2. Verify the installation:
-
-```bash
-crustomize --help
-```
-
-### Building from source
-
-If you prefer to build the binary yourself:
-
-1. Install dependencies with `bun install`.
-2. Build using `make bundle`.
-3. Copy the executable from `dist/` to your `$PATH`.
-
-See the examples under `examples/` for sample templates.


### PR DESCRIPTION
## Summary
- split Getting Started section from index into its own page
- link to the new page from the docs index

## Testing
- `npm test` *(fails: Cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686806f27ed48321ae61d6198ed09b65