### PR TITLE
Add config file support for CLI flags

### DIFF
--- a/.crustomizerc
+++ b/.crustomizerc
@@ -1,0 +1,2 @@
+lint: true
+output: .generated

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1,0 +1,17 @@
+# `.crustomizerc` file
+
+Command line flags can be stored in a `.crustomizerc` file written in YAML. When
+running `crustomize` it will look for this file in the current working directory.
+You may also specify an alternative path using the `--config` flag.
+
+Example:
+
+```yaml
+render: ejs
+profile: my-profile
+```
+
+Values in the config file are used as defaults. Flags passed on the command line
+override the config values. However, `render` and `profile` settings in
+`crustomize.yml` override both.
+

--- a/docs/crustomize-yml.md
+++ b/docs/crustomize-yml.md
@@ -1,0 +1,29 @@
+# `crustomize.yml` file
+
+Each variant directory contains a **crustomize.yml** manifest describing how to build
+your templates. All fields are optional except `base`. If `render` or `profile` are
+specified, they override the corresponding command line flags.
+
+```yaml
+base: ../base
+render: ejs
+profile: my-aws-profile
+overlays:
+  - ./Template.yml
+values:
+  Foo: true
+```
+
+## Fields
+
+| Field | Description |
+| ----- | ----------- |
+| `base` | Path to the directory containing base templates. |
+| `overlays` | List of overlay files to merge with the base templates. |
+| `params` | Path to a `params.yml` file converted to JSON when applying. |
+| `render` | Template engine (`handlebars` or `ejs`). Overrides `--render` if set. |
+| `profile` | AWS CLI profile used by helper functions. Overrides `--profile`. |
+| `stack` | CloudFormation stack information for deployment commands. |
+| `values` | Arbitrary values accessible from templates. |
+| `patches` | JSON patch operations applied after merging templates. |
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Crustomize lets you build reproducible AWS CloudFormation deployments by merging
 - Writing templates and overlays
 - Deploying to AWS
 - References
-  - crustomize.yml file
+  - [crustomize.yml file](crustomize-yml.md)
+  - [.crustomizerc config](config-file.md)
   - [Helper functions](helpers.md)
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-Crustomize expects a directory containing a **crustomize.yml** manifest. The manifest defines the base templates, overlay files, optional parameters and stack information. A common layout is to keep reusable base templates under a `base/` folder and variants that inherit from the base under `variants/`.
+Crustomize expects a directory containing a **crustomize.yml** manifest. The manifest defines the base templates, overlay files, optional parameters, stack information and optional settings like the render engine and AWS profile. These settings override the corresponding command line flags. A common layout is to keep reusable base templates under a `base/` folder and variants that inherit from the base under `variants/`.
 
 ```
 my-app/
@@ -24,6 +24,8 @@ The `crustomize.yml` file inside each variant references the base directory and 
 
 ```yaml
 base: ../base
+render: handlebars
+profile: my-profile
 overlays:
   - ./Template.yml
 stack:

--- a/index.ts
+++ b/index.ts
@@ -20,14 +20,15 @@ const cli = meow(
   Parameters:
     <path> Path to overlay folder
   Options
-    --render, -r    Template engine
+    --render, -r    Template engine, default is "handlebars"
     --output, -o    Output directory
-    --profile, -p   AWS CLI profile
+    --profile, -p   AWS CLI profile, default is "default"
     --config, -c    Config file with flag defaults
     --lint, -l      Lint the output file (requires cfn-lint)
     --env, -e       Environment file
     --help, -h      Show help
     --version, -v   Show version
+    --ci, -i        CI/CD mode
   Description:
     Applies overlays in <path> and performs pre-processing
     before outputting results to stdout or --output path
@@ -43,11 +44,16 @@ const cli = meow(
         default: false,
         aliases: ["v"],
       },
+      ci: {
+        type: "boolean",
+        isRequired: false,
+        default: false,
+        aliases: ["i"],
+      },
       profile: {
         type: "string",
         isRequired: false,
         aliases: ["p"],
-        // default: "default",
       },
       render: {
         type: "string",

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import meow from "meow"
 import { commands } from "./lib/commands/"
-import {version} from "./package.json"
+import { applyConfig } from "./lib/config"
+import { version } from "./package.json"
 
 const cli = meow(
   `
@@ -19,9 +20,10 @@ const cli = meow(
   Parameters:
     <path> Path to overlay folder
   Options
-    --render, -r    Template engine [Default: handlebars]
-    --output, -o    Output file [Default: standard out]
-    --profile, -p   AWS CLI profile [Default: default]
+    --render, -r    Template engine
+    --output, -o    Output directory
+    --profile, -p   AWS CLI profile
+    --config, -c    Config file with flag defaults
     --lint, -l      Lint the output file (requires cfn-lint)
     --env, -e       Environment file
     --help, -h      Show help
@@ -51,7 +53,11 @@ const cli = meow(
         type: "string",
         isRequired: false,
         aliases: ["r"],
-        default: "handlebars",
+      },
+      config: {
+        type: "string",
+        isRequired: false,
+        aliases: ["c"],
       },
       output: {
         type: "string",
@@ -92,6 +98,7 @@ if (command == undefined) {
 
 if (isCommand(command)) {
   if (path) {
+    applyConfig(cli.flags)
     await commands[command](path, cli.flags)
   } else {
     cli.showHelp()

--- a/lib/commands/apply.ts
+++ b/lib/commands/apply.ts
@@ -85,7 +85,18 @@ export const apply: ApplyFunction = async (crustomizePath, flags) => {
   }
   try {
     const manifest = getManifest(crustomizePath)
-    
+
+    // Manifest values override any provided flags
+    if (manifest.render) {
+      flags.render = manifest.render
+    } else if (!flags.render) {
+      flags.render = "handlebars"
+    }
+
+    if (manifest.profile) {
+      flags.profile = manifest.profile
+    }
+
     // If the manifest defines params, then the --output parameter is required.
     if (manifest.params && !flags.output) {
       console.error(

--- a/lib/commands/apply.ts
+++ b/lib/commands/apply.ts
@@ -89,10 +89,7 @@ export const apply: ApplyFunction = async (crustomizePath, flags) => {
     // Manifest values override any provided flags
     if (manifest.render) {
       flags.render = manifest.render
-    } else if (!flags.render) {
-      flags.render = "handlebars"
     }
-
     if (manifest.profile) {
       flags.profile = manifest.profile
     }

--- a/lib/commands/create-change-set.ts
+++ b/lib/commands/create-change-set.ts
@@ -36,6 +36,17 @@ export const createChangeSet: ApplyFunction = async (crustomizePath, flags) => {
 
     const manifest = getManifest(crustomizePath)
 
+    // Manifest values override any provided flags
+    if (manifest.render) {
+      flags.render = manifest.render
+    } else if (!flags.render) {
+      flags.render = "handlebars"
+    }
+
+    if (manifest.profile) {
+      flags.profile = manifest.profile
+    }
+
     if (!manifest.stack) {
       console.error("'stack' is required in the manifest for this operation.")
       process.exit(1)

--- a/lib/commands/create-change-set.ts
+++ b/lib/commands/create-change-set.ts
@@ -24,7 +24,7 @@ function stackExists(stackName: string, profile?: string): boolean {
 
 export const createChangeSet: ApplyFunction = async (crustomizePath, flags) => {
   let spinner: Ora | undefined
-  if (!flags.silent) {
+  if (!flags.ci) {
     spinner = ora("Creating CloudFormation change set...").start()
   } else {
     console.log("Creating CloudFormation change set...")
@@ -39,10 +39,7 @@ export const createChangeSet: ApplyFunction = async (crustomizePath, flags) => {
     // Manifest values override any provided flags
     if (manifest.render) {
       flags.render = manifest.render
-    } else if (!flags.render) {
-      flags.render = "handlebars"
     }
-
     if (manifest.profile) {
       flags.profile = manifest.profile
     }

--- a/lib/commands/delete-change-set.ts
+++ b/lib/commands/delete-change-set.ts
@@ -22,6 +22,17 @@ export const deleteChangeSet: ApplyFunction = async (crustomizePath, flags) => {
 
     const manifest = getManifest(crustomizePath)
 
+    // Manifest values override any provided flags
+    if (manifest.render) {
+      flags.render = manifest.render
+    } else if (!flags.render) {
+      flags.render = "handlebars"
+    }
+
+    if (manifest.profile) {
+      flags.profile = manifest.profile
+    }
+
     if (!manifest.stack) {
       console.error("'stack' is required in the manifest for this operation.")
       process.exit(1)

--- a/lib/commands/delete-change-set.ts
+++ b/lib/commands/delete-change-set.ts
@@ -10,7 +10,7 @@ import { cleanUpAwsFiles } from "../cleanup";
 
 export const deleteChangeSet: ApplyFunction = async (crustomizePath, flags) => {
   let spinner: Ora | undefined
-  if (!flags.silent) {
+  if (!flags.ci) {
     spinner = ora("Deleting CloudFormation change set...").start()
   } else {
     console.log("Deleting CloudFormation change set...")
@@ -25,10 +25,7 @@ export const deleteChangeSet: ApplyFunction = async (crustomizePath, flags) => {
     // Manifest values override any provided flags
     if (manifest.render) {
       flags.render = manifest.render
-    } else if (!flags.render) {
-      flags.render = "handlebars"
     }
-
     if (manifest.profile) {
       flags.profile = manifest.profile
     }

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -9,7 +9,7 @@ import { cleanUpAwsFiles } from "../cleanup";
 
 export const deploy: ApplyFunction = async (crustomizePath, flags) => {
   let spinner: Ora | undefined
-  if (!flags.silent) {
+  if (!flags.ci) {
     spinner = ora("Deploying CloudFormation stack...").start()
   } else {
     console.log("Deploying CloudFormation stack...")
@@ -24,10 +24,7 @@ export const deploy: ApplyFunction = async (crustomizePath, flags) => {
     // Manifest values override any provided flags
     if (manifest.render) {
       flags.render = manifest.render
-    } else if (!flags.render) {
-      flags.render = "handlebars"
     }
-
     if (manifest.profile) {
       flags.profile = manifest.profile
     }

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -21,6 +21,17 @@ export const deploy: ApplyFunction = async (crustomizePath, flags) => {
 
     const manifest = getManifest(crustomizePath)
 
+    // Manifest values override any provided flags
+    if (manifest.render) {
+      flags.render = manifest.render
+    } else if (!flags.render) {
+      flags.render = "handlebars"
+    }
+
+    if (manifest.profile) {
+      flags.profile = manifest.profile
+    }
+
     if (!manifest.stack) {
       console.error("'stack' is required in the manifest for deployment.")
       process.exit(1)

--- a/lib/commands/execute-change-set.ts
+++ b/lib/commands/execute-change-set.ts
@@ -10,7 +10,7 @@ import { cleanUpAwsFiles } from "../cleanup";
 
 export const executeChangeSet: ApplyFunction = async (crustomizePath, flags) => {
   let spinner: Ora | undefined
-  if (!flags.silent) {
+  if (!flags.ci) {
     spinner = ora("Executing CloudFormation change set...").start()
   } else {
     console.log("Executing CloudFormation change set...")
@@ -25,10 +25,7 @@ export const executeChangeSet: ApplyFunction = async (crustomizePath, flags) => 
     // Manifest values override any provided flags
     if (manifest.render) {
       flags.render = manifest.render
-    } else if (!flags.render) {
-      flags.render = "handlebars"
     }
-
     if (manifest.profile) {
       flags.profile = manifest.profile
     }

--- a/lib/commands/execute-change-set.ts
+++ b/lib/commands/execute-change-set.ts
@@ -22,6 +22,17 @@ export const executeChangeSet: ApplyFunction = async (crustomizePath, flags) => 
 
     const manifest = getManifest(crustomizePath)
 
+    // Manifest values override any provided flags
+    if (manifest.render) {
+      flags.render = manifest.render
+    } else if (!flags.render) {
+      flags.render = "handlebars"
+    }
+
+    if (manifest.profile) {
+      flags.profile = manifest.profile
+    }
+
     if (!manifest.stack) {
       console.error("'stack' is required in the manifest for this operation.")
       process.exit(1)

--- a/lib/commands/types.d.ts
+++ b/lib/commands/types.d.ts
@@ -1,10 +1,11 @@
 export type Flags = {
-  profile?: string
-  output?: string
-  render?: string
+  config?: string
   env?: string
-  silent?: boolean
   lint?: boolean
+  output?: string
+  profile?: string
+  render?: string
+  ci?: boolean
 }
 
 export type ApplyFunction = (path: string, flags: Flags) => Promise<void>

--- a/lib/commands/types.d.ts
+++ b/lib/commands/types.d.ts
@@ -1,7 +1,7 @@
 export type Flags = {
   profile?: string
   output?: string
-  render: string
+  render?: string
   env?: string
   silent?: boolean
   lint?: boolean

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,8 +1,9 @@
 import fs from "fs"
 import path from "path"
 import { yamlParse } from "yaml-cfn"
+import type { Flags } from "./commands/types.d"
 
-export function applyConfig(flags: Record<string, any>) {
+export function applyConfig(flags: Flags) {
   const configPath = flags.config
     ? path.resolve(process.cwd(), flags.config)
     : path.resolve(process.cwd(), ".crustomizerc")
@@ -10,14 +11,34 @@ export function applyConfig(flags: Record<string, any>) {
     try {
       const file = fs.readFileSync(configPath, "utf8").toString()
       const cfg = yamlParse(file) as Record<string, any>
+      const validKeys = [
+        "env",
+        "lint",
+        "output",
+        "profile",
+        "render",
+        "silent",
+      ] as (keyof Flags)[]
       for (const [key, value] of Object.entries(cfg)) {
-        if (flags[key] === undefined || flags[key] === "") {
-          flags[key] = value
+        if (!validKeys.includes(key as keyof Flags)) {
+          throw new Error(`Error reading .crustomizerc - unknown config key: ${key}`)
+
+        }
+        if (flags[key as keyof Flags] === undefined || flags[key as keyof Flags] === "") {
+          flags[key as keyof Flags] = value
         }
       }
-    } catch (_) {
+      // Set default values if not already set
+      if (flags.render === undefined) {
+        flags.render = "handlebars"
+      }
+      if (flags.profile === undefined) {
+        flags.profile = "default"
+      }
+    } catch (e) {
       console.error(`Unable to load config file: ${configPath}`)
+      console.error((e as Error).message)
+      process.exit(1)
     }
   }
 }
-

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,23 @@
+import fs from "fs"
+import path from "path"
+import { yamlParse } from "yaml-cfn"
+
+export function applyConfig(flags: Record<string, any>) {
+  const configPath = flags.config
+    ? path.resolve(process.cwd(), flags.config)
+    : path.resolve(process.cwd(), ".crustomizerc")
+  if (fs.existsSync(configPath)) {
+    try {
+      const file = fs.readFileSync(configPath, "utf8").toString()
+      const cfg = yamlParse(file) as Record<string, any>
+      for (const [key, value] of Object.entries(cfg)) {
+        if (flags[key] === undefined || flags[key] === "") {
+          flags[key] = value
+        }
+      }
+    } catch (_) {
+      console.error(`Unable to load config file: ${configPath}`)
+    }
+  }
+}
+

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -14,6 +14,8 @@ export type CrustomizeManifest = {
   base: string
   overlays?: string[]
   params?: string
+  render?: string
+  profile?: string
   stack?: {
     name: string
     capabilities?: string[]

--- a/lib/schemas/crustomize.json
+++ b/lib/schemas/crustomize.json
@@ -40,6 +40,13 @@
     "params": {
       "type": "string"
     },
+    "render": {
+      "type": "string",
+      "enum": ["handlebars", "ejs"]
+    },
+    "profile": {
+      "type": "string"
+    },
     "values": {
       "type": "object",
       "not": {

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ because the overlays will basically do this for you.
 
 For a more detailed guide and additional documentation see
 [docs/index.md](docs/index.md).
+You may store default CLI flags in a `.crustomizerc` file in your project
+directory. See [docs/config-file.md](docs/config-file.md) for details.
 
 ## Usage
 Like kustomize, crustomize allows you to create base CloudFormation templates

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -58,3 +58,22 @@ test("creates output directory if missing", async () => {
   fs.rmSync(outputPath, { recursive: true, force: true })
 })
 
+test("manifest values override flags", async () => {
+  const crustomizePath = "tests/fixtures/manifest_defaults"
+  const flags: any = {
+    render: "handlebars",
+    profile: "cli-prof",
+  }
+  let results = ""
+  const old = console.log
+  try {
+    console.log = (r) => { results = r }
+    await apply(crustomizePath, flags)
+  } finally {
+    console.log = old
+  }
+  expect(flags.render).toBe("ejs")
+  expect(flags.profile).toBe("testprof")
+  expect(results).toContain("ExpirationInDays: 123")
+})
+

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test"
+import { applyConfig } from "../lib/config"
+
+const configPath = "tests/fixtures/config_defaults/.crustomizerc"
+
+test("loads defaults from config file", () => {
+  const flags: any = { config: configPath }
+  applyConfig(flags)
+  expect(flags.render).toBe("ejs")
+  expect(flags.profile).toBe("confprof")
+})
+

--- a/tests/fixtures/config_defaults/.crustomizerc
+++ b/tests/fixtures/config_defaults/.crustomizerc
@@ -1,0 +1,2 @@
+render: ejs
+profile: confprof

--- a/tests/fixtures/manifest_defaults/S3.yml
+++ b/tests/fixtures/manifest_defaults/S3.yml
@@ -1,0 +1,16 @@
+Resources:
+  S3Bucket:
+    Properties:
+      BucketName: <%= values.BucketName %>
+<% if (values.Versioned) { %>
+      VersioningConfiguration:
+        Status: Enabled
+<% } %>
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireOldVersions
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            ExpirationInDays: <%= values.ExpirationInDays %>
+      Tags:
+<%= indent(toYaml(values.Tags), 6) %>

--- a/tests/fixtures/manifest_defaults/crustomize.yml
+++ b/tests/fixtures/manifest_defaults/crustomize.yml
@@ -1,0 +1,14 @@
+base: ../base
+render: ejs
+profile: testprof
+overlays:
+  - ./S3.yml
+values:
+  BucketName: mybucket
+  Versioned: true
+  ExpirationInDays: 123
+  Tags:
+    - Key: Name
+      Value: mybucket
+    - Key: Environment
+      Value: dev


### PR DESCRIPTION
## Summary
- support `.crustomizerc` file for default CLI flags
- update help text and default flag logic
- document the config file and link from docs and README
- unit test for config file loading
- allow manifest values to override CLI flags

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68691097194c83218a6eb8d568389367